### PR TITLE
possible fix for boot animation

### DIFF
--- a/rootdir/fstab.mt6735
+++ b/rootdir/fstab.mt6735
@@ -28,7 +28,7 @@
 
 
 
-/dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/oem /oem ext4 ro,noatime,barrier=1 wait
+#/dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/oem /oem ext4 ro,noatime,barrier=1 wait
 
 /devices/mtk-msdc.0/11230000.msdc0* auto vfat defaults voldmanaged=sdcard0:auto
 /devices/mtk-msdc.0/11240000.msdc1* auto auto defaults voldmanaged=sdcard1:auto,encryptable=userdata,noemulatedsd


### PR DESCRIPTION
/oem probably is not used in lineage? if so comment it out. bootanim should then default to the system/media bootanimation.zip (Lineage one) when it cannot find /oem
nice work BTW jmpfbmx